### PR TITLE
Fix bug in random tie-break

### DIFF
--- a/tests/test_RulePlurality.py
+++ b/tests/test_RulePlurality.py
@@ -50,6 +50,12 @@ def test_exact_precision():
     assert sum(plurality.scores_.values()) == 1
 
 
+def test_random_tie_break():
+    for i in range(5):
+        rule = RulePlurality(['a', 'b'], tie_break=Priority.RANDOM)
+        assert rule.winner_ == rule.strict_order_[0]
+
+
 def test_old_plurality_unweighted_winner():
     assert RulePlurality(["A", "A", "B", "A", "C"]).winner_ == "A"
     assert RulePlurality(["A", "A", "B", "C", "", "", ""]).winner_ == "A"

--- a/whalrus/rule/Rule.py
+++ b/whalrus/rule/Rule.py
@@ -117,7 +117,12 @@ class Rule(DeleteCacheMixin):
         :return: the winner of the election. This is the first candidate in :attr:`strict_order_` and also the
             choice of the tie-breaking rule in :attr:`cowinners_`.
         """
-        return self.tie_break.choice(self.cowinners_)
+        if len(self.cowinners_) == 1:
+            # Avoid computing the full order if it is not necessary.
+            return list(self.cowinners_)[0]
+        else:
+            # Ensure that the same tie-break is used as for the order (especially if random tie-break).
+            return self.strict_order_[0]
 
     @cached_property
     def cotrailers_(self) -> NiceSet:
@@ -138,7 +143,12 @@ class Rule(DeleteCacheMixin):
         :return: the "trailer" of the election. This is the last candidate in :attr:`strict_order_` and also the
             unfavorable choice of the tie-breaking rule in :attr:`cotrailers_`.
         """
-        return self.tie_break.choice(self.cotrailers_, reverse=True)
+        if len(self.cotrailers_) == 1:
+            # Avoid computing the full order if it is not necessary.
+            return list(self.cotrailers_)[0]
+        else:
+            # Ensure that the same tie-break is used as for the order (especially if random tie-break).
+            return self.strict_order_[-1]
 
     @cached_property
     def order_(self) -> list:


### PR DESCRIPTION
Bug: in Rule, the tie-break was applied independently to compute the winner (from cowinners) and the strict order (from the weak order). For deterministic tie-break rules, that was consistent, but for a random tie-breaking rule, it could lead to inconsistent choices.
This bug is fixed.