### PR TITLE
ADD: Import function for Preflib

### DIFF
--- a/tests/utils/test_Preflib.py
+++ b/tests/utils/test_Preflib.py
@@ -1,0 +1,17 @@
+from whalrus.utils.preflib_io import profile_from_preflib
+from whalrus.ballots.ballot_order import BallotOrder
+
+
+def test_profile_preflib():
+    file ="""
+1: 3,1,2,4
+2: 3,{1,2},4
+3: {1,2},3,4
+4: 4,{3,2,1}
+"""
+    assert profile_from_preflib(file) == [
+        BallotOrder([3,1,2,4]),
+        BallotOrder([3,{1,2},4]),
+        BallotOrder([{1,2},3,4]),
+        BallotOrder([4,{1,2,3}])
+        ]

--- a/tests/utils/test_Preflib.py
+++ b/tests/utils/test_Preflib.py
@@ -1,17 +1,71 @@
 from whalrus.utils.preflib_io import profile_from_preflib
 from whalrus.ballots.ballot_order import BallotOrder
+import pytest
 
-
-def test_profile_preflib():
+def test_profile_preflib_toi():
     file ="""
-1: 3,1,2,4
-2: 3,{1,2},4
-3: {1,2},3,4
-4: 4,{3,2,1}
+# FILE NAME: foo.toi
+# TITLE: Foo Election
+# DESCRIPTION: Some Description
+# DATA TYPE: toi
+# ALTERNATIVE NAME 1: Anna
+# ALTERNATIVE NAME 2: Belle
+# ALTERNATIVE NAME 3: Chris
+# ALTERNATIVE NAME 4: Dave
+1: 3,1,2
+3: 3,{1,2},4
+2: {1,2},3,4
+1: 4,{3,2,1}
 """
-    assert profile_from_preflib(file) == [
-        BallotOrder([3,1,2,4]),
-        BallotOrder([3,{1,2},4]),
-        BallotOrder([{1,2},3,4]),
-        BallotOrder([4,{1,2,3}])
+    assert profile_from_preflib(raw_data=file) == [
+        BallotOrder([3,1,2], candidates={1,2,3,4}),
+        BallotOrder([3,{1,2},4], candidates={1,2,3,4}),
+        BallotOrder([3,{1,2},4], candidates={1,2,3,4}),
+        BallotOrder([3,{1,2},4], candidates={1,2,3,4}),
+        BallotOrder([{1,2},3,4], candidates={1,2,3,4}),
+        BallotOrder([{1,2},3,4], candidates={1,2,3,4}),
+        BallotOrder([4,{1,2,3}], candidates={1,2,3,4})
         ]
+
+def test_profile_preflib_soi():
+    file ="""
+# FILE NAME: foo.soi
+# TITLE: Foo Election
+# DESCRIPTION: Some Description
+# DATA TYPE: soi
+# ALTERNATIVE NAME 1: Anna
+# ALTERNATIVE NAME 2: Belle
+# ALTERNATIVE NAME 3: Chris
+# ALTERNATIVE NAME 4: Dave
+1: 3,1,2
+2: 3,4
+1: 1,2,4
+1: 4,3,2
+"""
+    assert profile_from_preflib(raw_data=file) == [
+        BallotOrder([3,1,2], candidates={1,2,3,4}),
+        BallotOrder([3,4], candidates={1,2,3,4}),
+        BallotOrder([3,4], candidates={1,2,3,4}),
+        BallotOrder([1,2,4], candidates={1,2,3,4}),
+        BallotOrder([4,3,2], candidates={1,2,3,4}),
+        ]
+
+def test_profile_preflib_unsupported():
+    file ="""
+# FILE NAME: foo.cat
+# TITLE: Foo Election
+# DESCRIPTION: Some Description
+# DATA TYPE: cat
+# CATEGORY NAME 1: Yes
+# CATEGORY NAME 2: No
+# ALTERNATIVE NAME 1: Anna
+# ALTERNATIVE NAME 2: Belle
+# ALTERNATIVE NAME 3: Chris
+# ALTERNATIVE NAME 4: Dave
+1: {3,1},2
+2: 3,4
+1: {1,2},4
+1: {4,3},2
+"""
+    with pytest.raises(ValueError):
+        profile_from_preflib(raw_data=file)

--- a/whalrus/utils/preflib_io.py
+++ b/whalrus/utils/preflib_io.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from whalrus.ballots.ballot_order import BallotOrder
+
+
+def profile_from_preflib(preflib_file):
+    profile = list()
+    for line in preflib_file.split("\n"):
+        if len(line) == 0:
+            continue
+        if line[0] == "#":
+            continue
+
+        votername = line.split(":")[0].strip()
+        order_str = line.split(":")[1].strip()
+        order = list()
+        while len(order_str) > 0:
+            if order_str[0] == "{":
+                next_group = order_str[:order_str.find("}")]
+                next_group = next_group.replace("{", "")
+                next_group = next_group.replace("}", "")
+                order.append(
+                    {int(candidate) for candidate in next_group.split(",")}
+                    )
+                order_str = order_str[
+                    min(order_str.find("}")+2, len(order_str)):
+                    len(order_str)
+                    ]
+            elif order_str.find(",") != -1:
+                next_candidate = order_str[:order_str.find(",")]
+                order.append(int(next_candidate))
+                order_str = order_str[order_str.find(",")+1 : len(order_str)]
+            else:
+                order.append(int(order_str))
+                break
+        profile.append(BallotOrder(order))
+    return profile

--- a/whalrus/utils/preflib_io.py
+++ b/whalrus/utils/preflib_io.py
@@ -3,15 +3,42 @@
 from whalrus.ballots.ballot_order import BallotOrder
 
 
-def profile_from_preflib(preflib_file):
+def profile_from_preflib(raw_data=None, file_path=None):
+    if raw_data == None and file_path == None:
+        raise ValueError("Either raw_data or file_path must be specified.")
+    if raw_data == None:
+        f = open(file_path, "r")
+        raw_data = f.read()
+        f.close()
+    
+    # Check Datatype
+    if raw_data.find("# DATA TYPE") != -1:
+        raw_data = raw_data[raw_data.find("# Data Type") + 11:]
+        dtype = raw_data[:raw_data.find("\n")]
+        if not ("toc" in dtype or "toi" in dtype or "soi" in dtype or "soc" in dtype):
+            raise ValueError("The input describes an unsupported datatype.", dtype)
+    else:
+         raise ValueError("The input has unknown datatype.")
+
+    # Load Metadata
+    alternatives = dict()
+    while raw_data.find("# ALTERNATIVE NAME") != -1:
+        raw_data = raw_data[raw_data.find("# ALTERNATIVE NAME") + 18:]
+        alternative_num = int(raw_data[:raw_data.find(":")])
+        raw_data = raw_data[raw_data.find(":") + 1:]
+        alternative_name = raw_data[:raw_data.find("\n")]
+        raw_data = raw_data[raw_data.find("\n"):]
+        alternatives[alternative_num] = alternative_name
+
+    # Load Profile
     profile = list()
-    for line in preflib_file.split("\n"):
+    for line in raw_data.split("\n"):
         if len(line) == 0:
             continue
         if line[0] == "#":
             continue
 
-        votername = line.split(":")[0].strip()
+        multiplicity = int(line.split(":")[0].strip())
         order_str = line.split(":")[1].strip()
         order = list()
         while len(order_str) > 0:
@@ -19,9 +46,10 @@ def profile_from_preflib(preflib_file):
                 next_group = order_str[:order_str.find("}")]
                 next_group = next_group.replace("{", "")
                 next_group = next_group.replace("}", "")
-                order.append(
-                    {int(candidate) for candidate in next_group.split(",")}
-                    )
+                if len(next_group) > 0:
+                    order.append(
+                        {int(candidate) for candidate in next_group.split(",")}
+                        )
                 order_str = order_str[
                     min(order_str.find("}")+2, len(order_str)):
                     len(order_str)
@@ -33,5 +61,6 @@ def profile_from_preflib(preflib_file):
             else:
                 order.append(int(order_str))
                 break
-        profile.append(BallotOrder(order))
+        for i in range(multiplicity):
+            profile.append(BallotOrder(order, candidates=alternatives.keys()))
     return profile


### PR DESCRIPTION
This adds a basic function to import files from [Preflib](https://www.preflib.org) to whalrus. You can now import all sorts of ordinal ranks directly from the given dataset file to the internal datastructures from whalrus.

